### PR TITLE
Update Browsersync

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Aldryn Boilerplate Standard
 ===========================
 
+3.0.11
+------
+- update browser-sync to v2
+
 3.0.10
 ------
 - added ckeditor.wysiwyg.js temporarily to js/modules/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,7 @@ var patterns = {
     'sass': [paths.sass + '*', paths.sass + '**/*']
 };
 
-var port = process.env.PORT || '8000';
+var port = parseInt(process.env.PORT, 10) || 8000;
 
 // TASKS
 //##########################################################
@@ -78,7 +78,11 @@ gulp.task('browser', function () {
     // DOCS: http://www.browsersync.io/docs/options/
     setTimeout(function () {
         browserSync.init(files, {
-            'proxy': '0.0.0.0:' + port
+            'proxy': '0.0.0.0:' + port,
+            'port': port + 1,
+            'ui': {
+                'port': port + 2
+            }
         });
     }, 1000);
 });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "package",
   "private": true,
   "dependencies": {
-    "browser-sync": "^1.8.3",
+    "browser-sync": "^2.2.1",
     "gulp": "~3.8.10",
     "gulp-cached": "~1.0.1",
     "gulp-csscomb": "~3.0.3",


### PR DESCRIPTION
There's a new browsersync with ui and weinre included which is extremely helpful.
Also I updated gulpfile to be able to use ports you want.
Basically if you run a project with `make run PORT=8005` it will run project on 8005, browsersync on 8006 (instead of always 3000) and browsersync UI on 8007.