### PR TITLE
move dependencies to devDependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Aldryn Boilerplate Bootstrap 3
 ##############################
 
+Unreleased
+==========
+- move tooling in package.json from dependencies to devDependencies
+
 
 3.3.4
 =====

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "package",
     "private": true,
-    "dependencies": {
+    "devDependencies": {
         "browser-sync": "2.7.12",
         "gulp": "3.9.0",
         "gulp-cached": "1.1.0",


### PR DESCRIPTION
At the moment there is no visible difference, but the enduser might eventually start using dependencies field for actual libraries, and tooling we have should be in devDependencies.