### PR TITLE
Add new jshint options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,6 @@
 {
     "browser": true,
+    "devel": true,
     "esnext": true,
     "expr": true,
     "bitwise": true,
@@ -16,5 +17,6 @@
     "quotmark": "single",
     "strict": true,
     "unused": true,
-    "trailing": true
+    "trailing": true,
+    "undef": true
 }


### PR DESCRIPTION
`devel: true` stops warnings about `alert`, `console` et al
`undef: true` warns about things being not defined inside the current file (e.g. implied globals)