### PR TITLE
Aldryn does not copy required files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Aldryn Boilerplate Bootstrap 3
 ##############################
 
 
+4.0.1
+=====
+- fixed dependency linking for Aldryn
+
+
 4.0.0
 =====
 - added libsass support

--- a/boilerplate.json
+++ b/boilerplate.json
@@ -1,7 +1,7 @@
 {
     "identifier": "bootstrap3",
     "package-name": "aldryn-boilerplate-bootstrap3-libsass",
-    "version": "4.0.0",
+    "version": "4.0.1",
     "templates": [
         ["fullwidth.html", "full width"],
         ["sidebar_left.html", "sidebar left"],
@@ -26,6 +26,15 @@
         "static/js/libs/jquery.min.js",
         "static/js/libs/outdatedBrowser.min.js",
         "static/js/libs/respond.min.js",
-        "static/js/libs/swfobject.min.js"
+        "static/js/libs/swfobject.min.js",
+
+        ".bowerrc",
+        ".editorconfig",
+        ".jscsrc",
+        ".jshintrc",
+        "bower.json",
+        "browserslist",
+        "gulpfile.js",
+        "package.json"
     ]
 }


### PR DESCRIPTION
Aldryn takes the *protected* arguments from `boilerplate.json` and copy only the root files listed there to the project.