### PR TITLE
Add gitignore

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,11 @@ Aldryn Boilerplate Bootstrap 3
 ##############################
 
 
+4.0.2
+=====
+- added gitignore to Aldryn protected files
+
+
 4.0.1
 =====
 - fixed dependency linking for Aldryn

--- a/boilerplate.json
+++ b/boilerplate.json
@@ -28,6 +28,7 @@
         "static/js/libs/respond.min.js",
         "static/js/libs/swfobject.min.js",
 
+        ".gitignore",
         ".bowerrc",
         ".editorconfig",
         ".jscsrc",


### PR DESCRIPTION
Mostly in order to avoid `node_modules` committed automatically by aldryn client