### PR TITLE
add .gitignore for /static/css/base.css

### DIFF
--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,0 +1,1 @@
+/css/base.css


### PR DESCRIPTION
It should not be in git, since we create it at build time with our libsass setup.

TBD. @FinalAngel @vxsx what do you think? Is this change to specific for how we use this boilerplate on aldryn?