### PR TITLE
fix release list in documentation

### DIFF
--- a/docs/contribution/index.rst
+++ b/docs/contribution/index.rst
@@ -76,13 +76,13 @@ to be merged.
 Releases
 ********
 
-- Adapt the
-`CHANGELOG.rst <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/blob/master/CHANGELOG.rst>`_
+- Adapt the `CHANGELOG.rst <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/blob/master/CHANGELOG.rst>`_
 - Adapt `AUTHORS.rst <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/blob/master/AUTHORS.rst>`_ if required
 - Bump version in `boilerplate.json <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/blob/master/boilerplate.json>`_
 - Create a `GitHub tag <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/tags>`_
-- Add the release notes on the `GitHub tag <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/releases>`_ 
+- Add the release notes on the `GitHub tag <https://github.com/aldryn/aldryn-boilerplate-bootstrap3/releases>`_
 - Build new tag on `readthedocs.org <https://readthedocs.org/projects/aldryn-boilerplate-bootstrap3/>`_
 - Run ``bash tools/release.sh`` before release on `Aldryn <http://control.aldryn.com>`_
 - Run ``aldryn boilerplate upload`` to release on `Aldryn <http://control.aldryn.com>`_
 - Test, inform, present
+


### PR DESCRIPTION
before
<img width="805" alt="screen_shot_2015-11-03_at_13 25 211" src="https://cloud.githubusercontent.com/assets/366813/11020026/91fd5eba-8612-11e5-8188-8429f82273d2.png">

after
<img width="763" alt="screen shot 2015-11-08 at 12 15 54" src="https://cloud.githubusercontent.com/assets/366813/11020027/98c35c22-8612-11e5-9900-c139a34ae400.png">
